### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/classCompass_docker_experimental.yml
+++ b/.github/workflows/classCompass_docker_experimental.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - experimental
+      - deploy_experimental
 
 jobs:
   push_to_registry:
@@ -37,7 +37,8 @@ jobs:
           context: .
           file: ./setup/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            hannesschniz/classcompass:experimental
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation

--- a/.github/workflows/classCompass_docker_stable.yml
+++ b/.github/workflows/classCompass_docker_stable.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - stable
+      - deploy_stable
 
 jobs:
   push_to_registry:
@@ -37,7 +37,10 @@ jobs:
           context: .
           file: ./setup/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            hannesschniz/classcompass:latest
+            hannesschniz/classcompass:v1.0.0
+            hannesschniz/classcompass:stable
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation


### PR DESCRIPTION
This pull request updates the Docker image tagging process in the GitHub Actions workflows for both experimental and stable builds. The main change is a shift from using automatically generated tags to explicitly specifying tags for each build, which improves clarity and consistency in image versioning.

**Docker image tagging updates:**

* In `.github/workflows/classCompass_docker_experimental.yml`, the experimental Docker image is now explicitly tagged as `hannesschniz/classcompass:experimental` instead of using automatically generated tags.
* In `.github/workflows/classCompass_docker_stable.yml`, the stable Docker image is now explicitly tagged with multiple tags: `hannesschniz/classcompass:latest`, `hannesschniz/classcompass:v1.0.0`, and `hannesschniz/classcompass:stable`, replacing the previous use of automatically generated tags.