### PR TITLE
test deploy

### DIFF
--- a/.github/workflows/classCompass_docker_experimental.yml
+++ b/.github/workflows/classCompass_docker_experimental.yml
@@ -37,7 +37,8 @@ jobs:
           context: .
           file: ./setup/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            hannesschniz/classcompass:experimental
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation

--- a/.github/workflows/classCompass_docker_stable.yml
+++ b/.github/workflows/classCompass_docker_stable.yml
@@ -37,7 +37,10 @@ jobs:
           context: .
           file: ./setup/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            hannesschniz/classcompass:latest
+            hannesschniz/classcompass:v1.0.0
+            hannesschniz/classcompass:stable
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation


### PR DESCRIPTION
This pull request updates the Docker image tagging strategy in the GitHub Actions workflows for both experimental and stable builds. The main goal is to simplify and standardize how images are tagged when pushed to the registry.

**Docker image tagging updates:**

* In `.github/workflows/classCompass_docker_experimental.yml`, the experimental image is now tagged as `hannesschniz/classcompass:experimental` instead of using dynamic tags generated by the workflow.
* In `.github/workflows/classCompass_docker_stable.yml`, the stable image is now tagged with three explicit tags: `hannesschniz/classcompass:latest`, `hannesschniz/classcompass:v1.0.0`, and `hannesschniz/classcompass:stable`, replacing the previous dynamic tagging.